### PR TITLE
helm chart: add nodeSelector to DaemonSets

### DIFF
--- a/helm/kubernetes-gpu-app/templates/device-plugin-ds.yaml
+++ b/helm/kubernetes-gpu-app/templates/device-plugin-ds.yaml
@@ -21,6 +21,9 @@ spec:
     spec:
       serviceAccount: nvidia-gpu-device-plugin
       serviceAccountName: nvidia-gpu-device-plugin
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
       tolerations:
       - key: "node.kubernetes.io/master"
         effect: "NoSchedule"

--- a/helm/kubernetes-gpu-app/templates/nvidia-driver-ds.yaml
+++ b/helm/kubernetes-gpu-app/templates/nvidia-driver-ds.yaml
@@ -16,6 +16,9 @@ spec:
     spec:
       serviceAccount: nvidia-driver-installer
       serviceAccountName: nvidia-driver-installer
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{ .Values.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
       tolerations:
       - key: "node.kubernetes.io/master"
         effect: "NoSchedule"


### PR DESCRIPTION
With this PR, the helm chart allows specifying a node selector. This way, the DaemonSets will only run on specific nodes.

By default, no node selector is active, therefore the DaemonSets are scheduled on all nodes.

### Example values

```yml
nodeSelector:
  beta.kubernetes.io/instance-type: Standard_NC6s_v2
```